### PR TITLE
Fix #44, #46: roff: Clean up unnecessary dot escaping, fix dot escaping in NF environments

### DIFF
--- a/lib/ronn/roff.rb
+++ b/lib/ronn/roff.rb
@@ -256,7 +256,9 @@ module Ronn
       text.gsub!(/&#(\d+);/) { $1.to_i.chr }                # dec entities
       text.gsub!('\\', '\e')                                # backslash
       text.gsub!('...', '\|.\|.\|.')                        # ellipses
-      text.gsub!(/['.-]/) { |m| "\\#{m}" }                  # control chars
+      # lines cannot start with a '.', insert zero-width character before
+      text.gsub!(/^\./, '\\\\&.')                           # dot at line start
+      text.gsub!(/['-]/) { |m| "\\#{m}" }                   # control chars
       text.gsub!(/(&[A-Za-z]+;)/) { ent[$1] || $1 }         # named entities
       text.gsub!('&amp;',  '&')                             # amps
       text
@@ -269,11 +271,6 @@ module Ronn
     # write text to output buffer
     def write(text)
       return if text.nil? || text.empty?
-      # lines cannot start with a '.'. insert zero-width character before.
-      if text[0,2] == '\.' &&
-        (@buf.last && @buf.last[-1] == ?\n)
-        @buf << '\&'
-      end
       @buf << text
     end
 

--- a/test/definition_list_syntax.roff
+++ b/test/definition_list_syntax.roff
@@ -22,5 +22,5 @@ new paragraphs
 .
 .TP
 \fB\-\-somearg\fR=\fIVALUE\fR
-We can do that too\.
+We can do that too.
 

--- a/test/dots_at_line_start_test.roff
+++ b/test/dots_at_line_start_test.roff
@@ -8,3 +8,18 @@ There\'s a weird issue where dots at the beginning of a line generate troff warn
 .
 .P
 \&\.\. let\'s see what happens\.
+.
+.IP "" 4
+.
+.nf
+
+\&\. This dot is escaped correctly\.
+
+a test
+b test
+\&\. This one is not\.
+.
+.fi
+.
+.IP "" 0
+

--- a/test/dots_at_line_start_test.roff
+++ b/test/dots_at_line_start_test.roff
@@ -4,22 +4,27 @@
 \fBdots_at_line_start_test\fR
 .
 .P
-There\'s a weird issue where dots at the beginning of a line generate troff warnings due to escaping\.
+There\'s a weird issue where dots at the beginning of a line generate troff warnings due to escaping.
 .
 .P
-\&\.\. let\'s see what happens\.
+\&.. let\'s see what happens.
 .
 .IP "" 4
 .
 .nf
 
-\&\. This dot is escaped correctly\.
+\&. This dot is escaped correctly.
 
 a test
 b test
-\&\. This one is not\.
+\&. This one is too.
 .
 .fi
 .
 .IP "" 0
-
+.
+.P
+\&.
+.
+.P
+(Single dots should get replaced correctly, too.)

--- a/test/dots_at_line_start_test.ronn
+++ b/test/dots_at_line_start_test.ronn
@@ -2,3 +2,9 @@ There's a weird issue where dots at the beginning of a line
 generate troff warnings due to escaping.
 
 .. let's see what happens.
+
+    . This dot is escaped correctly.
+
+    a test
+    b test
+    . This one is not.

--- a/test/dots_at_line_start_test.ronn
+++ b/test/dots_at_line_start_test.ronn
@@ -7,4 +7,8 @@ generate troff warnings due to escaping.
 
     a test
     b test
-    . This one is not.
+    . This one is too.
+
+.
+
+(Single dots should get replaced correctly, too.)

--- a/test/ellipses.roff
+++ b/test/ellipses.roff
@@ -4,7 +4,7 @@
 \fBellipses\fR \- testing ellipses
 .
 .P
-Ellipses should be replaced\|\.\|\.\|\.
+Ellipses should be replaced\|.\|.\|.
 .
 .P
-\|\.\|\.\|\.also, they shouldn\'t interfere with regular dots at the beginning of a line\.
+\|.\|.\|.also, they shouldn\'t interfere with regular dots at the beginning of a line.

--- a/test/entity_encoding_test.roff
+++ b/test/entity_encoding_test.roff
@@ -58,4 +58,4 @@ Here\'s some special entities:
 .IP "" 0
 .
 .P
-Here\'s a line that uses non\-breaking spaces to force the last\~few\~words\~to\~wrap\~together\.
+Here\'s a line that uses non\-breaking spaces to force the last\~few\~words\~to\~wrap\~together.

--- a/test/markdown_syntax.roff
+++ b/test/markdown_syntax.roff
@@ -13,16 +13,16 @@
 #### Header 4 ####
 ##### Header 5 #####
 
-This is a paragraph, which is text surrounded by whitespace\.
+This is a paragraph, which is text surrounded by whitespace.
 Paragraphs can be on one line (or many), and can drone on for
-hours\.
+hours.
 
-[Reference style links][1] and [inline links](http://example\.com)
-[1]: http://example\.com "Title is optional"
+[Reference style links][1] and [inline links](http://example.com)
+[1]: http://example.com "Title is optional"
 
-Inline markup like _italics_,  **bold**, and `code()`\.
+Inline markup like _italics_,  **bold**, and `code()`.
 
-![picture alt](/images/photo\.jpeg "Title is optional")
+![picture alt](/images/photo.jpeg "Title is optional")
 
 > Blockquotes are like quoted text in email replies
 >> And, they can be nested
@@ -42,25 +42,25 @@ Inline markup like _italics_,  **bold**, and `code()`\.
 .SH "DESCRIPTION"
 .
 .SS "Philosophy"
-Markdown is intended to be as easy\-to\-read and easy\-to\-write as is feasible\.
+Markdown is intended to be as easy\-to\-read and easy\-to\-write as is feasible.
 .
 .P
-Readability, however, is emphasized above all else\. A Markdown\-formatted document should be publishable as\-is, as plain text, without looking like it\'s been marked up with tags or formatting instructions\. While Markdown\'s syntax has been influenced by several existing text\-to\-HTML filters \-\- including Setext \fIhttp://docutils\.sourceforge\.net/mirror/setext\.html\fR, atx \fIhttp://www\.aaronsw\.com/2002/atx/\fR, Textile \fIhttp://textism\.com/tools/textile/\fR, reStructuredText \fIhttp://docutils\.sourceforge\.net/rst\.html\fR, Grutatext \fIhttp://www\.triptico\.com/software/grutatxt\.html\fR, and EtText \fIhttp://ettext\.taint\.org/doc/\fR \-\- the single biggest source of inspiration for Markdown\'s syntax is the format of plain text email\.
+Readability, however, is emphasized above all else. A Markdown\-formatted document should be publishable as\-is, as plain text, without looking like it\'s been marked up with tags or formatting instructions. While Markdown\'s syntax has been influenced by several existing text\-to\-HTML filters \-\- including Setext \fIhttp://docutils.sourceforge.net/mirror/setext.html\fR, atx \fIhttp://www.aaronsw.com/2002/atx/\fR, Textile \fIhttp://textism.com/tools/textile/\fR, reStructuredText \fIhttp://docutils.sourceforge.net/rst.html\fR, Grutatext \fIhttp://www.triptico.com/software/grutatxt.html\fR, and EtText \fIhttp://ettext.taint.org/doc/\fR \-\- the single biggest source of inspiration for Markdown\'s syntax is the format of plain text email.
 .
 .P
-To this end, Markdown\'s syntax is comprised entirely of punctuation characters, which punctuation characters have been carefully chosen so as to look like what they mean\. E\.g\., asterisks around a word actually look like *emphasis*\. Markdown lists look like, well, lists\. Even blockquotes look like quoted passages of text, assuming you\'ve ever used email\.
+To this end, Markdown\'s syntax is comprised entirely of punctuation characters, which punctuation characters have been carefully chosen so as to look like what they mean. E.g., asterisks around a word actually look like *emphasis*. Markdown lists look like, well, lists. Even blockquotes look like quoted passages of text, assuming you\'ve ever used email.
 .
 .SS "Inline HTML"
-Markdown\'s syntax is intended for one purpose: to be used as a format for \fIwriting\fR for the web\.
+Markdown\'s syntax is intended for one purpose: to be used as a format for \fIwriting\fR for the web.
 .
 .P
-Markdown is not a replacement for HTML, or even close to it\. Its syntax is very small, corresponding only to a very small subset of HTML tags\. The idea is \fInot\fR to create a syntax that makes it easier to insert HTML tags\. In my opinion, HTML tags are already easy to insert\. The idea for Markdown is to make it easy to read, write, and edit prose\. HTML is a \fIpublishing\fR format; Markdown is a \fIwriting\fR format\. Thus, Markdown\'s formatting syntax only addresses issues that can be conveyed in plain text\.
+Markdown is not a replacement for HTML, or even close to it. Its syntax is very small, corresponding only to a very small subset of HTML tags. The idea is \fInot\fR to create a syntax that makes it easier to insert HTML tags. In my opinion, HTML tags are already easy to insert. The idea for Markdown is to make it easy to read, write, and edit prose. HTML is a \fIpublishing\fR format; Markdown is a \fIwriting\fR format. Thus, Markdown\'s formatting syntax only addresses issues that can be conveyed in plain text.
 .
 .P
-For any markup that is not covered by Markdown\'s syntax, you simply use HTML itself\. There\'s no need to preface it or delimit it to indicate that you\'re switching from Markdown to HTML; you just use the tags\.
+For any markup that is not covered by Markdown\'s syntax, you simply use HTML itself. There\'s no need to preface it or delimit it to indicate that you\'re switching from Markdown to HTML; you just use the tags.
 .
 .P
-The only restrictions are that block\-level HTML elements \-\- e\.g\. \fB<div>\fR, \fB<table>\fR, \fB<pre>\fR, \fB<p>\fR, etc\. \-\- must be separated from surrounding content by blank lines, and the start and end tags of the block should not be indented with tabs or spaces\. Markdown is smart enough not to add extra (unwanted) \fB<p>\fR tags around HTML block\-level tags\.
+The only restrictions are that block\-level HTML elements \-\- e.g. \fB<div>\fR, \fB<table>\fR, \fB<pre>\fR, \fB<p>\fR, etc. \-\- must be separated from surrounding content by blank lines, and the start and end tags of the block should not be indented with tabs or spaces. Markdown is smart enough not to add extra (unwanted) \fB<p>\fR tags around HTML block\-level tags.
 .
 .P
 For example, to add an HTML table to a Markdown article:
@@ -69,7 +69,7 @@ For example, to add an HTML table to a Markdown article:
 .
 .nf
 
-This is a regular paragraph\.
+This is a regular paragraph.
 
 <table>
     <tr>
@@ -77,32 +77,32 @@ This is a regular paragraph\.
     </tr>
 </table>
 
-This is another regular paragraph\.
+This is another regular paragraph.
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Note that Markdown formatting syntax is not processed within block\-level HTML tags\. E\.g\., you can\'t use Markdown\-style \fB*emphasis*\fR inside an HTML block\.
+Note that Markdown formatting syntax is not processed within block\-level HTML tags. E.g., you can\'t use Markdown\-style \fB*emphasis*\fR inside an HTML block.
 .
 .P
-Span\-level HTML tags \-\- e\.g\. \fB<span>\fR, \fB<cite>\fR, or \fB<del>\fR \-\- can be used anywhere in a Markdown paragraph, list item, or header\. If you want, you can even use HTML tags instead of Markdown formatting; e\.g\. if you\'d prefer to use HTML \fB<a>\fR or \fB<img>\fR tags instead of Markdown\'s link or image syntax, go right ahead\.
+Span\-level HTML tags \-\- e.g. \fB<span>\fR, \fB<cite>\fR, or \fB<del>\fR \-\- can be used anywhere in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead of Markdown formatting; e.g. if you\'d prefer to use HTML \fB<a>\fR or \fB<img>\fR tags instead of Markdown\'s link or image syntax, go right ahead.
 .
 .P
-Unlike block\-level HTML tags, Markdown syntax \fIis\fR processed within span\-level tags\.
+Unlike block\-level HTML tags, Markdown syntax \fIis\fR processed within span\-level tags.
 .
 .SS "Automatic Escaping for Special Characters"
-In HTML, there are two characters that demand special treatment: \fB<\fR and \fB&\fR\. Left angle brackets are used to start tags; ampersands are used to denote HTML entities\. If you want to use them as literal characters, you must escape them as entities, e\.g\. \fB&lt;\fR, and \fB&amp;\fR\.
+In HTML, there are two characters that demand special treatment: \fB<\fR and \fB&\fR\&. Left angle brackets are used to start tags; ampersands are used to denote HTML entities. If you want to use them as literal characters, you must escape them as entities, e.g. \fB&lt;\fR, and \fB&amp;\fR\&.
 .
 .P
-Ampersands in particular are bedeviling for web writers\. If you want to write about \'AT&T\', you need to write \'\fBAT&amp;T\fR\'\. You even need to escape ampersands within URLs\. Thus, if you want to link to:
+Ampersands in particular are bedeviling for web writers. If you want to write about \'AT&T\', you need to write \'\fBAT&amp;T\fR\'. You even need to escape ampersands within URLs. Thus, if you want to link to:
 .
 .IP "" 4
 .
 .nf
 
-http://images\.google\.com/images?num=30&q=larry+bird
+http://images.google.com/images?num=30&q=larry+bird
 .
 .fi
 .
@@ -115,17 +115,17 @@ you need to encode the URL as:
 .
 .nf
 
-http://images\.google\.com/images?num=30&amp;q=larry+bird
+http://images.google.com/images?num=30&amp;q=larry+bird
 .
 .fi
 .
 .IP "" 0
 .
 .P
-in your anchor tag \fBhref\fR attribute\. Needless to say, this is easy to forget, and is probably the single most common source of HTML validation errors in otherwise well\-marked\-up web sites\.
+in your anchor tag \fBhref\fR attribute. Needless to say, this is easy to forget, and is probably the single most common source of HTML validation errors in otherwise well\-marked\-up web sites.
 .
 .P
-Markdown allows you to use these characters naturally, taking care of all the necessary escaping for you\. If you use an ampersand as part of an HTML entity, it remains unchanged; otherwise it will be translated into \fB&amp;\fR\.
+Markdown allows you to use these characters naturally, taking care of all the necessary escaping for you. If you use an ampersand as part of an HTML entity, it remains unchanged; otherwise it will be translated into \fB&amp;\fR\&.
 .
 .P
 So, if you want to include a copyright symbol in your article, you can write:
@@ -141,7 +141,7 @@ So, if you want to include a copyright symbol in your article, you can write:
 .IP "" 0
 .
 .P
-and Markdown will leave it alone\. But if you write:
+and Markdown will leave it alone. But if you write:
 .
 .IP "" 4
 .
@@ -167,7 +167,7 @@ AT&amp;T
 .IP "" 0
 .
 .P
-Similarly, because Markdown supports \fIinline HTML\fR, if you use angle brackets as delimiters for HTML tags, Markdown will treat them as such\. But if you write:
+Similarly, because Markdown supports \fIinline HTML\fR, if you use angle brackets as delimiters for HTML tags, Markdown will treat them as such. But if you write:
 .
 .IP "" 4
 .
@@ -193,27 +193,27 @@ Markdown will translate it to:
 .IP "" 0
 .
 .P
-However, inside Markdown code spans and blocks, angle brackets and ampersands are \fIalways\fR encoded automatically\. This makes it easy to use Markdown to write about HTML code\. (As opposed to raw HTML, which is a terrible format for writing about HTML syntax, because every single \fB<\fR and \fB&\fR in your example code needs to be escaped\.)
+However, inside Markdown code spans and blocks, angle brackets and ampersands are \fIalways\fR encoded automatically. This makes it easy to use Markdown to write about HTML code. (As opposed to raw HTML, which is a terrible format for writing about HTML syntax, because every single \fB<\fR and \fB&\fR in your example code needs to be escaped.)
 .
 .SH "BLOCK ELEMENTS"
 .
 .SS "Paragraphs and Line Breaks"
-A paragraph is simply one or more consecutive lines of text, separated by one or more blank lines\. (A blank line is any line that looks like a blank line \-\- a line containing nothing but spaces or tabs is considered blank\.) Normal paragraphs should not be indented with spaces or tabs\.
+A paragraph is simply one or more consecutive lines of text, separated by one or more blank lines. (A blank line is any line that looks like a blank line \-\- a line containing nothing but spaces or tabs is considered blank.) Normal paragraphs should not be indented with spaces or tabs.
 .
 .P
-The implication of the "one or more consecutive lines of text" rule is that Markdown supports "hard\-wrapped" text paragraphs\. This differs significantly from most other text\-to\-HTML formatters (including Movable Type\'s "Convert Line Breaks" option) which translate every line break character in a paragraph into a \fB<br />\fR tag\.
+The implication of the "one or more consecutive lines of text" rule is that Markdown supports "hard\-wrapped" text paragraphs. This differs significantly from most other text\-to\-HTML formatters (including Movable Type\'s "Convert Line Breaks" option) which translate every line break character in a paragraph into a \fB<br />\fR tag.
 .
 .P
-When you \fIdo\fR want to insert a \fB<br />\fR break tag using Markdown, you end a line with two or more spaces, then type return\.
+When you \fIdo\fR want to insert a \fB<br />\fR break tag using Markdown, you end a line with two or more spaces, then type return.
 .
 .P
-Yes, this takes a tad more effort to create a \fB<br />\fR, but a simplistic "every line break is a \fB<br />\fR" rule wouldn\'t work for Markdown\. Markdown\'s email\-style \fIblockquoting\fR and multi\-paragraph \fIlist items\fR work best \-\- and look better \-\- when you format them with hard breaks\.
+Yes, this takes a tad more effort to create a \fB<br />\fR, but a simplistic "every line break is a \fB<br />\fR" rule wouldn\'t work for Markdown. Markdown\'s email\-style \fIblockquoting\fR and multi\-paragraph \fIlist items\fR work best \-\- and look better \-\- when you format them with hard breaks.
 .
 .SS "Headers"
-Markdown supports two styles of headers, Setext \fIhttp://docutils\.sourceforge\.net/mirror/setext\.html\fR and atx \fIhttp://www\.aaronsw\.com/2002/atx/\fR\.
+Markdown supports two styles of headers, Setext \fIhttp://docutils.sourceforge.net/mirror/setext.html\fR and atx \fIhttp://www.aaronsw.com/2002/atx/\fR\&.
 .
 .P
-Setext\-style headers are "underlined" using equal signs (for first\-level headers) and dashes (for second\-level headers)\. For example:
+Setext\-style headers are "underlined" using equal signs (for first\-level headers) and dashes (for second\-level headers). For example:
 .
 .IP "" 4
 .
@@ -230,10 +230,10 @@ This is an H2
 .IP "" 0
 .
 .P
-Any number of underlining \fB=\fR\'s or \fB\-\fR\'s will work\.
+Any number of underlining \fB=\fR\'s or \fB\-\fR\'s will work.
 .
 .P
-Atx\-style headers use 1\-6 hash characters at the start of the line, corresponding to header levels 1\-6\. For example:
+Atx\-style headers use 1\-6 hash characters at the start of the line, corresponding to header levels 1\-6. For example:
 .
 .IP "" 4
 .
@@ -250,7 +250,7 @@ Atx\-style headers use 1\-6 hash characters at the start of the line, correspond
 .IP "" 0
 .
 .P
-Optionally, you may "close" atx\-style headers\. This is purely cosmetic \-\- you can use this if you think it looks better\. The closing hashes don\'t even need to match the number of hashes used to open the header\. (The number of opening hashes determines the header level\.) :
+Optionally, you may "close" atx\-style headers. This is purely cosmetic \-\- you can use this if you think it looks better. The closing hashes don\'t even need to match the number of hashes used to open the header. (The number of opening hashes determines the header level.) :
 .
 .IP "" 4
 .
@@ -267,18 +267,18 @@ Optionally, you may "close" atx\-style headers\. This is purely cosmetic \-\- yo
 .IP "" 0
 .
 .SS "Blockquotes"
-Markdown uses email\-style \fB>\fR characters for blockquoting\. If you\'re familiar with quoting passages of text in an email message, then you know how to create a blockquote in Markdown\. It looks best if you hard wrap the text and put a \fB>\fR before every line:
+Markdown uses email\-style \fB>\fR characters for blockquoting. If you\'re familiar with quoting passages of text in an email message, then you know how to create a blockquote in Markdown. It looks best if you hard wrap the text and put a \fB>\fR before every line:
 .
 .IP "" 4
 .
 .nf
 
-> This is a blockquote with two paragraphs\. Lorem ipsum dolor sit amet,
-> consectetuer adipiscing elit\. Aliquam hendrerit mi posuere lectus\.
-> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus\.
+> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+> consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 >
-> Donec sit amet nisl\. Aliquam semper ipsum sit amet velit\. Suspendisse
-> id sem consectetuer libero luctus adipiscing\.
+> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
+> id sem consectetuer libero luctus adipiscing.
 .
 .fi
 .
@@ -291,29 +291,29 @@ Markdown allows you to be lazy and only put the \fB>\fR before the first line of
 .
 .nf
 
-> This is a blockquote with two paragraphs\. Lorem ipsum dolor sit amet,
-consectetuer adipiscing elit\. Aliquam hendrerit mi posuere lectus\.
-Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus\.
+> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
-> Donec sit amet nisl\. Aliquam semper ipsum sit amet velit\. Suspendisse
-id sem consectetuer libero luctus adipiscing\.
+> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
+id sem consectetuer libero luctus adipiscing.
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Blockquotes can be nested (i\.e\. a blockquote\-in\-a\-blockquote) by adding additional levels of \fB>\fR:
+Blockquotes can be nested (i.e. a blockquote\-in\-a\-blockquote) by adding additional levels of \fB>\fR:
 .
 .IP "" 4
 .
 .nf
 
-> This is the first level of quoting\.
+> This is the first level of quoting.
 >
-> > This is nested blockquote\.
+> > This is nested blockquote.
 >
-> Back to the first level\.
+> Back to the first level.
 .
 .fi
 .
@@ -326,10 +326,10 @@ Blockquotes can contain other Markdown elements, including headers, lists, and c
 .
 .nf
 
-> ## This is a header\.
+> ## This is a header.
 >
-> 1\.   This is the first list item\.
-> 2\.   This is the second list item\.
+> 1.   This is the first list item.
+> 2.   This is the second list item.
 >
 > Here\'s some example code:
 >
@@ -340,10 +340,10 @@ Blockquotes can contain other Markdown elements, including headers, lists, and c
 .IP "" 0
 .
 .P
-Any decent text editor should make email\-style quoting easy\. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu\.
+Any decent text editor should make email\-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.
 .
 .SS "Lists"
-Markdown supports ordered (numbered) and unordered (bulleted) lists\.
+Markdown supports ordered (numbered) and unordered (bulleted) lists.
 .
 .P
 Unordered lists use asterisks, pluses, and hyphens \-\- interchangably \-\- as list markers:
@@ -397,16 +397,16 @@ Ordered lists use numbers followed by periods:
 .
 .nf
 
-1\.  Bird
-2\.  McHale
-3\.  Parish
+1.  Bird
+2.  McHale
+3.  Parish
 .
 .fi
 .
 .IP "" 0
 .
 .P
-It\'s important to note that the actual numbers you use to mark the list have no effect on the HTML output Markdown produces\. The HTML Markdown produces from the above list is:
+It\'s important to note that the actual numbers you use to mark the list have no effect on the HTML output Markdown produces. The HTML Markdown produces from the above list is:
 .
 .IP "" 4
 .
@@ -429,9 +429,9 @@ If you instead wrote the list in Markdown like this:
 .
 .nf
 
-1\.  Bird
-1\.  McHale
-1\.  Parish
+1.  Bird
+1.  McHale
+1.  Parish
 .
 .fi
 .
@@ -444,22 +444,22 @@ or even:
 .
 .nf
 
-3\. Bird
-1\. McHale
-8\. Parish
+3. Bird
+1. McHale
+8. Parish
 .
 .fi
 .
 .IP "" 0
 .
 .P
-you\'d get the exact same HTML output\. The point is, if you want to, you can use ordinal numbers in your ordered Markdown lists, so that the numbers in your source match the numbers in your published HTML\. But if you want to be lazy, you don\'t have to\.
+you\'d get the exact same HTML output. The point is, if you want to, you can use ordinal numbers in your ordered Markdown lists, so that the numbers in your source match the numbers in your published HTML. But if you want to be lazy, you don\'t have to.
 .
 .P
-If you do use lazy list numbering, however, you should still start the list with the number 1\. At some point in the future, Markdown may support starting ordered lists at an arbitrary number\.
+If you do use lazy list numbering, however, you should still start the list with the number 1. At some point in the future, Markdown may support starting ordered lists at an arbitrary number.
 .
 .P
-List markers typically start at the left margin, but may be indented by up to three spaces\. List markers must be followed by one or more spaces or a tab\.
+List markers typically start at the left margin, but may be indented by up to three spaces. List markers must be followed by one or more spaces or a tab.
 .
 .P
 To make lists look nice, you can wrap items with hanging indents:
@@ -468,11 +468,11 @@ To make lists look nice, you can wrap items with hanging indents:
 .
 .nf
 
-*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit\.
-    Aliquam hendrerit mi posuere lectus\. Vestibulum enim wisi,
-    viverra nec, fringilla in, laoreet vitae, risus\.
-*   Donec sit amet nisl\. Aliquam semper ipsum sit amet velit\.
-    Suspendisse id sem consectetuer libero luctus adipiscing\.
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
 .
 .fi
 .
@@ -485,18 +485,18 @@ But if you want to be lazy, you don\'t have to:
 .
 .nf
 
-*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit\.
-Aliquam hendrerit mi posuere lectus\. Vestibulum enim wisi,
-viverra nec, fringilla in, laoreet vitae, risus\.
-*   Donec sit amet nisl\. Aliquam semper ipsum sit amet velit\.
-Suspendisse id sem consectetuer libero luctus adipiscing\.
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+Suspendisse id sem consectetuer libero luctus adipiscing.
 .
 .fi
 .
 .IP "" 0
 .
 .P
-If list items are separated by blank lines, Markdown will wrap the items in \fB<p>\fR tags in the HTML output\. For example, this input:
+If list items are separated by blank lines, Markdown will wrap the items in \fB<p>\fR tags in the HTML output. For example, this input:
 .
 .IP "" 4
 .
@@ -557,21 +557,21 @@ will turn into:
 .IP "" 0
 .
 .P
-List items may consist of multiple paragraphs\. Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab:
+List items may consist of multiple paragraphs. Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab:
 .
 .IP "" 4
 .
 .nf
 
-1\.  This is a list item with two paragraphs\. Lorem ipsum dolor
-    sit amet, consectetuer adipiscing elit\. Aliquam hendrerit
-    mi posuere lectus\.
+1.  This is a list item with two paragraphs. Lorem ipsum dolor
+    sit amet, consectetuer adipiscing elit. Aliquam hendrerit
+    mi posuere lectus.
 
     Vestibulum enim wisi, viverra nec, fringilla in, laoreet
-    vitae, risus\. Donec sit amet nisl\. Aliquam semper ipsum
-    sit amet velit\.
+    vitae, risus. Donec sit amet nisl. Aliquam semper ipsum
+    sit amet velit.
 
-2\.  Suspendisse id sem consectetuer libero luctus adipiscing\.
+2.  Suspendisse id sem consectetuer libero luctus adipiscing.
 .
 .fi
 .
@@ -584,13 +584,13 @@ It looks nice if you indent every line of the subsequent paragraphs, but here ag
 .
 .nf
 
-*   This is a list item with two paragraphs\.
+*   This is a list item with two paragraphs.
 
-    This is the second paragraph in the list item\. You\'re
-only required to indent the first line\. Lorem ipsum dolor
-sit amet, consectetuer adipiscing elit\.
+    This is the second paragraph in the list item. You\'re
+only required to indent the first line. Lorem ipsum dolor
+sit amet, consectetuer adipiscing elit.
 
-*   Another item in the same list\.
+*   Another item in the same list.
 .
 .fi
 .
@@ -606,7 +606,7 @@ To put a blockquote within a list item, the blockquote\'s \fB>\fR delimiters nee
 *   A list item with a blockquote:
 
     > This is a blockquote
-    > inside a list item\.
+    > inside a list item.
 .
 .fi
 .
@@ -634,30 +634,30 @@ It\'s worth noting that it\'s possible to trigger an ordered list by accident, b
 .
 .nf
 
-1986\. What a great season\.
+1986. What a great season.
 .
 .fi
 .
 .IP "" 0
 .
 .P
-In other words, a \fInumber\-period\-space\fR sequence at the beginning of a line\. To avoid this, you can backslash\-escape the period:
+In other words, a \fInumber\-period\-space\fR sequence at the beginning of a line. To avoid this, you can backslash\-escape the period:
 .
 .IP "" 4
 .
 .nf
 
-1986\e\. What a great season\.
+1986\e. What a great season.
 .
 .fi
 .
 .IP "" 0
 .
 .SS "Code Blocks"
-Pre\-formatted code blocks are used for writing about programming or markup source code\. Rather than forming normal paragraphs, the lines of a code block are interpreted literally\. Markdown wraps a code block in both \fB<pre>\fR and \fB<code>\fR tags\.
+Pre\-formatted code blocks are used for writing about programming or markup source code. Rather than forming normal paragraphs, the lines of a code block are interpreted literally. Markdown wraps a code block in both \fB<pre>\fR and \fB<code>\fR tags.
 .
 .P
-To produce a code block in Markdown, simply indent every line of the block by at least 4 spaces or 1 tab\. For example, given this input:
+To produce a code block in Markdown, simply indent every line of the block by at least 4 spaces or 1 tab. For example, given this input:
 .
 .IP "" 4
 .
@@ -665,7 +665,7 @@ To produce a code block in Markdown, simply indent every line of the block by at
 
 This is a normal paragraph:
 
-    This is a code block\.
+    This is a code block.
 .
 .fi
 .
@@ -680,7 +680,7 @@ Markdown will generate:
 
 <p>This is a normal paragraph:</p>
 
-<pre><code>This is a code block\.
+<pre><code>This is a code block.
 </code></pre>
 .
 .fi
@@ -688,7 +688,7 @@ Markdown will generate:
 .IP "" 0
 .
 .P
-One level of indentation \-\- 4 spaces or 1 tab \-\- is removed from each line of the code block\. For example, this:
+One level of indentation \-\- 4 spaces or 1 tab \-\- is removed from each line of the code block. For example, this:
 .
 .IP "" 4
 .
@@ -723,10 +723,10 @@ end tell
 .IP "" 0
 .
 .P
-A code block continues until it reaches a line that is not indented (or the end of the article)\.
+A code block continues until it reaches a line that is not indented (or the end of the article).
 .
 .P
-Within a code block, ampersands (\fB&\fR) and angle brackets (\fB<\fR and \fB>\fR) are automatically converted into HTML entities\. This makes it very easy to include example HTML source code using Markdown \-\- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets\. For example, this:
+Within a code block, ampersands (\fB&\fR) and angle brackets (\fB<\fR and \fB>\fR) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown \-\- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:
 .
 .IP "" 4
 .
@@ -757,10 +757,10 @@ will turn into:
 .IP "" 0
 .
 .P
-Regular Markdown syntax is not processed within code blocks\. E\.g\., asterisks are just literal asterisks within a code block\. This means it\'s also easy to use Markdown to write about Markdown\'s own syntax\.
+Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it\'s also easy to use Markdown to write about Markdown\'s own syntax.
 .
 .SS "Horizontal Rules"
-You can produce a horizontal rule tag (\fB<hr />\fR) by placing three or more hyphens, asterisks, or underscores on a line by themselves\. If you wish, you may use spaces between the hyphens or asterisks\. Each of the following lines will produce a horizontal rule:
+You can produce a horizontal rule tag (\fB<hr />\fR) by placing three or more hyphens, asterisks, or underscores on a line by themselves. If you wish, you may use spaces between the hyphens or asterisks. Each of the following lines will produce a horizontal rule:
 .
 .IP "" 4
 .
@@ -783,21 +783,21 @@ You can produce a horizontal rule tag (\fB<hr />\fR) by placing three or more hy
 .SH "SPAN ELEMENTS"
 .
 .SS "Links"
-Markdown supports two style of links: \fIinline\fR and \fIreference\fR\.
+Markdown supports two style of links: \fIinline\fR and \fIreference\fR\&.
 .
 .P
-In both styles, the link text is delimited by [square brackets]\.
+In both styles, the link text is delimited by [square brackets].
 .
 .P
-To create an inline link, use a set of regular parentheses immediately after the link text\'s closing square bracket\. Inside the parentheses, put the URL where you want the link to point, along with an \fIoptional\fR title for the link, surrounded in quotes\. For example:
+To create an inline link, use a set of regular parentheses immediately after the link text\'s closing square bracket. Inside the parentheses, put the URL where you want the link to point, along with an \fIoptional\fR title for the link, surrounded in quotes. For example:
 .
 .IP "" 4
 .
 .nf
 
-This is [an example](http://example\.com/ "Title") inline link\.
+This is [an example](http://example.com/ "Title") inline link.
 
-[This link](http://example\.net/) has no title attribute\.
+[This link](http://example.net/) has no title attribute.
 .
 .fi
 .
@@ -810,11 +810,11 @@ Will produce:
 .
 .nf
 
-<p>This is <a href="http://example\.com/" title="Title">
-an example</a> inline link\.</p>
+<p>This is <a href="http://example.com/" title="Title">
+an example</a> inline link.</p>
 
-<p><a href="http://example\.net/">This link</a> has no
-title attribute\.</p>
+<p><a href="http://example.net/">This link</a> has no
+title attribute.</p>
 .
 .fi
 .
@@ -827,7 +827,7 @@ If you\'re referring to a local resource on the same server, you can use relativ
 .
 .nf
 
-See my [About](/about/) page for details\.
+See my [About](/about/) page for details.
 .
 .fi
 .
@@ -840,7 +840,7 @@ Reference\-style links use a second set of square brackets, inside which you pla
 .
 .nf
 
-This is [an example][id] reference\-style link\.
+This is [an example][id] reference\-style link.
 .
 .fi
 .
@@ -853,7 +853,7 @@ You can optionally use a space to separate the sets of brackets:
 .
 .nf
 
-This is [an example] [id] reference\-style link\.
+This is [an example] [id] reference\-style link.
 .
 .fi
 .
@@ -866,7 +866,7 @@ Then, anywhere in the document, you define your link label like this, on a line 
 .
 .nf
 
-[id]: http://example\.com/  "Optional Title Here"
+[id]: http://example.com/  "Optional Title Here"
 .
 .fi
 .
@@ -888,7 +888,7 @@ followed by one or more spaces (or tabs);
 followed by the URL for the link;
 .
 .IP "\[ci]" 4
-optionally followed by a title attribute for the link, enclosed in double or single quotes, or enclosed in parentheses\.
+optionally followed by a title attribute for the link, enclosed in double or single quotes, or enclosed in parentheses.
 .
 .IP "" 0
 .
@@ -899,16 +899,16 @@ The following three link definitions are equivalent:
 .
 .nf
 
-[foo]: http://example\.com/  "Optional Title Here"
-[foo]: http://example\.com/  \'Optional Title Here\'
-[foo]: http://example\.com/  (Optional Title Here)
+[foo]: http://example.com/  "Optional Title Here"
+[foo]: http://example.com/  \'Optional Title Here\'
+[foo]: http://example.com/  (Optional Title Here)
 .
 .fi
 .
 .IP "" 0
 .
 .P
-\fBNote:\fR There is a known bug in Markdown\.pl 1\.0\.1 which prevents single quotes from being used to delimit link titles\.
+\fBNote:\fR There is a known bug in Markdown.pl 1.0.1 which prevents single quotes from being used to delimit link titles.
 .
 .P
 The link URL may, optionally, be surrounded by angle brackets:
@@ -917,7 +917,7 @@ The link URL may, optionally, be surrounded by angle brackets:
 .
 .nf
 
-[id]: <http://example\.com/>  "Optional Title Here"
+[id]: <http://example.com/>  "Optional Title Here"
 .
 .fi
 .
@@ -930,7 +930,7 @@ You can put the title attribute on the next line and use extra spaces or tabs fo
 .
 .nf
 
-[id]: http://example\.com/longish/path/to/resource/here
+[id]: http://example.com/longish/path/to/resource/here
     "Optional Title Here"
 .
 .fi
@@ -938,10 +938,10 @@ You can put the title attribute on the next line and use extra spaces or tabs fo
 .IP "" 0
 .
 .P
-Link definitions are only used for creating links during Markdown processing, and are stripped from your document in the HTML output\.
+Link definitions are only used for creating links during Markdown processing, and are stripped from your document in the HTML output.
 .
 .P
-Link definition names may consist of letters, numbers, spaces, and punctuation \-\- but they are \fInot\fR case sensitive\. E\.g\. these two links:
+Link definition names may consist of letters, numbers, spaces, and punctuation \-\- but they are \fInot\fR case sensitive. E.g. these two links:
 .
 .IP "" 4
 .
@@ -955,10 +955,10 @@ Link definition names may consist of letters, numbers, spaces, and punctuation \
 .IP "" 0
 .
 .P
-are equivalent\.
+are equivalent.
 .
 .P
-The \fIimplicit link name\fR shortcut allows you to omit the name of the link, in which case the link text itself is used as the name\. Just use an empty set of square brackets \-\- e\.g\., to link the word "Google" to the google\.com web site, you could simply write:
+The \fIimplicit link name\fR shortcut allows you to omit the name of the link, in which case the link text itself is used as the name. Just use an empty set of square brackets \-\- e.g., to link the word "Google" to the google.com web site, you could simply write:
 .
 .IP "" 4
 .
@@ -977,7 +977,7 @@ And then define the link:
 .
 .nf
 
-[Google]: http://google\.com/
+[Google]: http://google.com/
 .
 .fi
 .
@@ -990,7 +990,7 @@ Because link names may contain spaces, this shortcut even works for multiple wor
 .
 .nf
 
-Visit [Daring Fireball][] for more information\.
+Visit [Daring Fireball][] for more information.
 .
 .fi
 .
@@ -1003,14 +1003,14 @@ And then define the link:
 .
 .nf
 
-[Daring Fireball]: http://daringfireball\.net/
+[Daring Fireball]: http://daringfireball.net/
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Link definitions can be placed anywhere in your Markdown document\. I tend to put them immediately after each paragraph in which they\'re used, but if you want, you can put them all at the end of your document, sort of like footnotes\.
+Link definitions can be placed anywhere in your Markdown document. I tend to put them immediately after each paragraph in which they\'re used, but if you want, you can put them all at the end of your document, sort of like footnotes.
 .
 .P
 Here\'s an example of reference links in action:
@@ -1020,11 +1020,11 @@ Here\'s an example of reference links in action:
 .nf
 
 I get 10 times more traffic from [Google] [1] than from
-[Yahoo] [2] or [MSN] [3]\.
+[Yahoo] [2] or [MSN] [3].
 
-  [1]: http://google\.com/        "Google"
-  [2]: http://search\.yahoo\.com/  "Yahoo Search"
-  [3]: http://search\.msn\.com/    "MSN Search"
+  [1]: http://google.com/        "Google"
+  [2]: http://search.yahoo.com/  "Yahoo Search"
+  [3]: http://search.msn.com/    "MSN Search"
 .
 .fi
 .
@@ -1038,11 +1038,11 @@ Using the implicit link name shortcut, you could instead write:
 .nf
 
 I get 10 times more traffic from [Google][] than from
-[Yahoo][] or [MSN][]\.
+[Yahoo][] or [MSN][].
 
-  [google]: http://google\.com/        "Google"
-  [yahoo]:  http://search\.yahoo\.com/  "Yahoo Search"
-  [msn]:    http://search\.msn\.com/    "MSN Search"
+  [google]: http://google.com/        "Google"
+  [yahoo]:  http://search.yahoo.com/  "Yahoo Search"
+  [msn]:    http://search.msn.com/    "MSN Search"
 .
 .fi
 .
@@ -1055,10 +1055,10 @@ Both of the above examples will produce the following HTML output:
 .
 .nf
 
-<p>I get 10 times more traffic from <a href="http://google\.com/"
+<p>I get 10 times more traffic from <a href="http://google.com/"
 title="Google">Google</a> than from
-<a href="http://search\.yahoo\.com/" title="Yahoo Search">Yahoo</a>
-or <a href="http://search\.msn\.com/" title="MSN Search">MSN</a>\.</p>
+<a href="http://search.yahoo.com/" title="Yahoo Search">Yahoo</a>
+or <a href="http://search.msn.com/" title="MSN Search">MSN</a>.</p>
 .
 .fi
 .
@@ -1071,22 +1071,22 @@ For comparison, here is the same paragraph written using Markdown\'s inline link
 .
 .nf
 
-I get 10 times more traffic from [Google](http://google\.com/ "Google")
-than from [Yahoo](http://search\.yahoo\.com/ "Yahoo Search") or
-[MSN](http://search\.msn\.com/ "MSN Search")\.
+I get 10 times more traffic from [Google](http://google.com/ "Google")
+than from [Yahoo](http://search.yahoo.com/ "Yahoo Search") or
+[MSN](http://search.msn.com/ "MSN Search").
 .
 .fi
 .
 .IP "" 0
 .
 .P
-The point of reference\-style links is not that they\'re easier to write\. The point is that with reference\-style links, your document source is vastly more readable\. Compare the above examples: using reference\-style links, the paragraph itself is only 81 characters long; with inline\-style links, it\'s 176 characters; and as raw HTML, it\'s 234 characters\. In the raw HTML, there\'s more markup than there is text\.
+The point of reference\-style links is not that they\'re easier to write. The point is that with reference\-style links, your document source is vastly more readable. Compare the above examples: using reference\-style links, the paragraph itself is only 81 characters long; with inline\-style links, it\'s 176 characters; and as raw HTML, it\'s 234 characters. In the raw HTML, there\'s more markup than there is text.
 .
 .P
-With Markdown\'s reference\-style links, a source document much more closely resembles the final output, as rendered in a browser\. By allowing you to move the markup\-related metadata out of the paragraph, you can add links without interrupting the narrative flow of your prose\.
+With Markdown\'s reference\-style links, a source document much more closely resembles the final output, as rendered in a browser. By allowing you to move the markup\-related metadata out of the paragraph, you can add links without interrupting the narrative flow of your prose.
 .
 .SS "Emphasis"
-Markdown treats asterisks (\fB*\fR) and underscores (\fB_\fR) as indicators of emphasis\. Text wrapped with one \fB*\fR or \fB_\fR will be wrapped with an HTML \fB<em>\fR tag; double \fB*\fR\'s or \fB_\fR\'s will be wrapped with an HTML \fB<strong>\fR tag\. E\.g\., this input:
+Markdown treats asterisks (\fB*\fR) and underscores (\fB_\fR) as indicators of emphasis. Text wrapped with one \fB*\fR or \fB_\fR will be wrapped with an HTML \fB<em>\fR tag; double \fB*\fR\'s or \fB_\fR\'s will be wrapped with an HTML \fB<strong>\fR tag. E.g., this input:
 .
 .IP "" 4
 .
@@ -1124,7 +1124,7 @@ will produce:
 .IP "" 0
 .
 .P
-You can use whichever style you prefer; the lone restriction is that the same character must be used to open and close an emphasis span\.
+You can use whichever style you prefer; the lone restriction is that the same character must be used to open and close an emphasis span.
 .
 .P
 Emphasis can be used in the middle of a word:
@@ -1140,7 +1140,7 @@ un*frigging*believable
 .IP "" 0
 .
 .P
-But if you surround an \fB*\fR or \fB_\fR with spaces, it\'ll be treated as a literal asterisk or underscore\.
+But if you surround an \fB*\fR or \fB_\fR with spaces, it\'ll be treated as a literal asterisk or underscore.
 .
 .P
 To produce a literal asterisk or underscore at a position where it would otherwise be used as an emphasis delimiter, you can backslash escape it:
@@ -1156,13 +1156,13 @@ To produce a literal asterisk or underscore at a position where it would otherwi
 .IP "" 0
 .
 .SS "Code"
-To indicate a span of code, wrap it with backtick quotes (\fB`\fR)\. Unlike a pre\-formatted code block, a code span indicates code within a normal paragraph\. For example:
+To indicate a span of code, wrap it with backtick quotes (\fB`\fR). Unlike a pre\-formatted code block, a code span indicates code within a normal paragraph. For example:
 .
 .IP "" 4
 .
 .nf
 
-Use the `printf()` function\.
+Use the `printf()` function.
 .
 .fi
 .
@@ -1175,7 +1175,7 @@ will produce:
 .
 .nf
 
-<p>Use the <code>printf()</code> function\.</p>
+<p>Use the <code>printf()</code> function.</p>
 .
 .fi
 .
@@ -1188,7 +1188,7 @@ To include a literal backtick character within a code span, you can use multiple
 .
 .nf
 
-``There is a literal backtick (`) here\.``
+``There is a literal backtick (`) here.``
 .
 .fi
 .
@@ -1201,14 +1201,14 @@ which will produce this:
 .
 .nf
 
-<p><code>There is a literal backtick (`) here\.</code></p>
+<p><code>There is a literal backtick (`) here.</code></p>
 .
 .fi
 .
 .IP "" 0
 .
 .P
-The backtick delimiters surrounding a code span may include spaces \-\- one after the opening, one before the closing\. This allows you to place literal backtick characters at the beginning or end of a code span:
+The backtick delimiters surrounding a code span may include spaces \-\- one after the opening, one before the closing. This allows you to place literal backtick characters at the beginning or end of a code span:
 .
 .IP "" 4
 .
@@ -1238,13 +1238,13 @@ will produce:
 .IP "" 0
 .
 .P
-With a code span, ampersands and angle brackets are encoded as HTML entities automatically, which makes it easy to include example HTML tags\. Markdown will turn this:
+With a code span, ampersands and angle brackets are encoded as HTML entities automatically, which makes it easy to include example HTML tags. Markdown will turn this:
 .
 .IP "" 4
 .
 .nf
 
-Please don\'t use any `<blink>` tags\.
+Please don\'t use any `<blink>` tags.
 .
 .fi
 .
@@ -1257,7 +1257,7 @@ into:
 .
 .nf
 
-<p>Please don\'t use any <code>&lt;blink&gt;</code> tags\.</p>
+<p>Please don\'t use any <code>&lt;blink&gt;</code> tags.</p>
 .
 .fi
 .
@@ -1270,7 +1270,7 @@ You can write this:
 .
 .nf
 
-`&#8212;` is the decimal\-encoded equivalent of `&mdash;`\.
+`&#8212;` is the decimal\-encoded equivalent of `&mdash;`.
 .
 .fi
 .
@@ -1284,17 +1284,17 @@ to produce:
 .nf
 
 <p><code>&amp;#8212;</code> is the decimal\-encoded
-equivalent of <code>&amp;mdash;</code>\.</p>
+equivalent of <code>&amp;mdash;</code>.</p>
 .
 .fi
 .
 .IP "" 0
 .
 .SS "Images"
-Admittedly, it\'s fairly difficult to devise a "natural" syntax for placing images into a plain text document format\.
+Admittedly, it\'s fairly difficult to devise a "natural" syntax for placing images into a plain text document format.
 .
 .P
-Markdown uses an image syntax that is intended to resemble the syntax for links, allowing for two styles: \fIinline\fR and \fIreference\fR\.
+Markdown uses an image syntax that is intended to resemble the syntax for links, allowing for two styles: \fIinline\fR and \fIreference\fR\&.
 .
 .P
 Inline image syntax looks like this:
@@ -1303,9 +1303,9 @@ Inline image syntax looks like this:
 .
 .nf
 
-![Alt text](/path/to/img\.jpg)
+![Alt text](/path/to/img.jpg)
 
-![Alt text](/path/to/img\.jpg "Optional title")
+![Alt text](/path/to/img.jpg "Optional title")
 .
 .fi
 .
@@ -1321,7 +1321,7 @@ An exclamation mark: \fB!\fR;
 followed by a set of square brackets, containing the \fBalt\fR attribute text for the image;
 .
 .IP "\[ci]" 4
-followed by a set of parentheses, containing the URL or path to the image, and an optional \fBtitle\fR attribute enclosed in double or single quotes\.
+followed by a set of parentheses, containing the URL or path to the image, and an optional \fBtitle\fR attribute enclosed in double or single quotes.
 .
 .IP "" 0
 .
@@ -1339,7 +1339,7 @@ Reference\-style image syntax looks like this:
 .IP "" 0
 .
 .P
-Where "id" is the name of a defined image reference\. Image references are defined using syntax identical to link references:
+Where "id" is the name of a defined image reference. Image references are defined using syntax identical to link references:
 .
 .IP "" 4
 .
@@ -1352,18 +1352,18 @@ Where "id" is the name of a defined image reference\. Image references are defin
 .IP "" 0
 .
 .P
-As of this writing, Markdown has no syntax for specifying the dimensions of an image; if this is important to you, you can simply use regular HTML \fB<img>\fR tags\.
+As of this writing, Markdown has no syntax for specifying the dimensions of an image; if this is important to you, you can simply use regular HTML \fB<img>\fR tags.
 .
 .SH "MISCELLANEOUS"
 .
 .SS "Automatic Links"
-Markdown supports a shortcut style for creating "automatic" links for URLs and email addresses: simply surround the URL or email address with angle brackets\. What this means is that if you want to show the actual text of a URL or email address, and also have it be a clickable link, you can do this:
+Markdown supports a shortcut style for creating "automatic" links for URLs and email addresses: simply surround the URL or email address with angle brackets. What this means is that if you want to show the actual text of a URL or email address, and also have it be a clickable link, you can do this:
 .
 .IP "" 4
 .
 .nf
 
-<http://example\.com/>
+<http://example.com/>
 .
 .fi
 .
@@ -1376,20 +1376,20 @@ Markdown will turn this into:
 .
 .nf
 
-<a href="http://example\.com/">http://example\.com/</a>
+<a href="http://example.com/">http://example.com/</a>
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Automatic links for email addresses work similarly, except that Markdown will also perform a bit of randomized decimal and hex entity\-encoding to help obscure your address from address\-harvesting spambots\. For example, Markdown will turn this:
+Automatic links for email addresses work similarly, except that Markdown will also perform a bit of randomized decimal and hex entity\-encoding to help obscure your address from address\-harvesting spambots. For example, Markdown will turn this:
 .
 .IP "" 4
 .
 .nf
 
-<address@example\.com>
+<address@example.com>
 .
 .fi
 .
@@ -1412,13 +1412,13 @@ into something like this:
 .IP "" 0
 .
 .P
-which will render in a browser as a clickable link to "address@example\.com"\.
+which will render in a browser as a clickable link to "address@example.com".
 .
 .P
-(This sort of entity\-encoding trick will indeed fool many, if not most, address\-harvesting bots, but it definitely won\'t fool all of them\. It\'s better than nothing, but an address published in this way will probably eventually start receiving spam\.)
+(This sort of entity\-encoding trick will indeed fool many, if not most, address\-harvesting bots, but it definitely won\'t fool all of them. It\'s better than nothing, but an address published in this way will probably eventually start receiving spam.)
 .
 .SS "Backslash Escapes"
-Markdown allows you to use backslash escapes to generate literal characters which would otherwise have special meaning in Markdown\'s formatting syntax\. For example, if you wanted to surround a word with literal asterisks (instead of an HTML \fB<em>\fR tag), you can use backslashes before the asterisks, like this:
+Markdown allows you to use backslash escapes to generate literal characters which would otherwise have special meaning in Markdown\'s formatting syntax. For example, if you wanted to surround a word with literal asterisks (instead of an HTML \fB<em>\fR tag), you can use backslashes before the asterisks, like this:
 .
 .IP "" 4
 .
@@ -1447,7 +1447,7 @@ _   underscore
 #   hash mark
 +   plus sign
 \-   minus sign (hyphen)
-\.   dot
+\&.   dot
 !   exclamation mark
 .
 .fi
@@ -1455,13 +1455,13 @@ _   underscore
 .IP "" 0
 .
 .SH "AUTHOR"
-Markdown was created by John Gruber\.
+Markdown was created by John Gruber.
 .
 .P
-Manual page by Ryan Tomayko\. It\'s pretty much a direct copy of the Markdown Syntax Reference \fIhttp://daringfireball\.net/projects/markdown/syntax\fR, also by John Gruber\.
+Manual page by Ryan Tomayko. It\'s pretty much a direct copy of the Markdown Syntax Reference \fIhttp://daringfireball.net/projects/markdown/syntax\fR, also by John Gruber.
 .
 .SH "SEE ALSO"
 ronn(5)
 .
 .br
-\fIhttp://daringfireball\.net/projects/markdown/\fR
+\fIhttp://daringfireball.net/projects/markdown/\fR

--- a/test/middle_paragraph.roff
+++ b/test/middle_paragraph.roff
@@ -7,7 +7,7 @@
 Foo
 .
 .P
-Always use \fBattr_reader\fR, \fBattr_writer\fR or \fBattr_accessor\fR\. Do not use \fBfor\|\.\|\.\|\.in\fR; use each instead\. Do not use \fBand\fR/\fBor\fR; use \fB&&\fR/\fB||\fR instead\.
+Always use \fBattr_reader\fR, \fBattr_writer\fR or \fBattr_accessor\fR\&. Do not use \fBfor\|.\|.\|.in\fR; use each instead. Do not use \fBand\fR/\fBor\fR; use \fB&&\fR/\fB||\fR instead.
 .
 .P
 Bar

--- a/test/missing_spaces.roff
+++ b/test/missing_spaces.roff
@@ -5,5 +5,5 @@
 .
 .TP
 \fB\-S\fR \fItext\fR, \fBsearch\fR \fItext\fR
-Performs a substring search of formula names for \fItext\fR\.
+Performs a substring search of formula names for \fItext\fR\&.
 

--- a/test/nested_list_with_code.roff
+++ b/test/nested_list_with_code.roff
@@ -4,7 +4,7 @@
 \fBtoggle_status\fR
 .
 .IP "\[ci]" 4
-Toggle the display of the status bar\.
+Toggle the display of the status bar.
 .
 .IP "" 0
 

--- a/test/section_reference_links.roff
+++ b/test/section_reference_links.roff
@@ -4,7 +4,7 @@
 \fBsection_reference_links\fR \- linking to sections
 .
 .SH "SECTION 1"
-See the following section\.
+See the following section.
 .
 .SH "SECTION 2"
 See \fISECTION 1\fR or \fIto put it another way\fR or even \fIlink this\fR

--- a/test/underline_spacing_test.roff
+++ b/test/underline_spacing_test.roff
@@ -8,14 +8,14 @@ This input
 .
 .TP
 \fB\-S\fR \fItext\fR, \fBsearch\fR \fItext\fR
-Performs a substring search of formula names for \fItext\fR\.
+Performs a substring search of formula names for \fItext\fR\&.
 .
 .TP
 \fB\-O\fR \fItext\fR, \fBother\fR \fItext\fR
-Does something else\.
+Does something else.
 .
 .P
-Should space text properly\.
+Should space text properly.
 .
 .P
 \fI!\-\- this is a comment \-\-\fR


### PR DESCRIPTION
This moves dot escaping at the beginning of a line from line to node level.

Fixes #44 and #46.

There's probably a better way to do this, but I figured it was at least cleaner than depending on implementation details in the write method which would have been another naïve solution.
