### PR TITLE
index file: support separating reference id from location using tabs

### DIFF
--- a/lib/ronn/index.rb
+++ b/lib/ronn/index.rb
@@ -49,7 +49,7 @@ module Ronn
       data.each_line do |line|
         line = line.strip.gsub(/\s*#.*$/, '')
         if !line.empty?
-          name, url = line.split(/ +/, 2)
+          name, url = line.split(/[ \t]+/, 2)
           @references << reference(name, url)
         end
       end


### PR DESCRIPTION
ronn(1) says:

```
Each line of the index file describes a single reference link, with
whitespace separating the reference's <id> from its <location>.
```

Until now, only the space character was accepted as whitespace. This commit adds support for tabs.
