### PR TITLE
Correctly extract the page name from the basename

### DIFF
--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -110,7 +110,7 @@ module Ronn
     # available. This is used as the manual page name when the
     # file contents do not include a name section.
     def path_name
-      @basename[/^[^.]+/] if @basename
+      $1 if @basename =~ /^(.+)\.[12345678]\.(?:ronn|md|mkdn?|markdown)$/
     end
 
     # Returns the <section> part of the path, or nil when

--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -461,7 +461,7 @@ module Ronn
         next if child_of?(node, 'a')
         next unless node.inner_text =~ /^#{name_pattern}$/
         sibling = node.next
-        next unless sibling.text?
+        next unless sibling && sibling.text?
         next unless sibling.content =~ /^\((\d+\w*)\)/
         node.swap(html_build_manual_reference_link(node, "(#{$1})"))
         sibling.content = sibling.content.gsub(/^\(\d+\w*\)/, '')


### PR DESCRIPTION
Before, page names like sysctl.conf or blueprint.cfg would not be allowed and instead would be truncated so an input file blueprint.cfg.5.ronn for blueprint.cfg(5) would write files blueprint.5 and blueprint.5.html.

5cabf64aba225b24edb4d1063a47042bef1bb5b3 is a fix for me being sloppy last August.  I can't figure out what's interacting badly with it but stack traces like this happen without this check:

```
/home/vagrant/work/ronn/lib/ronn/document.rb:465:in `html_filter_manual_reference_links': undefined method `text?' for nil:NilClass (NoMethodError)
        from /home/vagrant/work/ronn/lib/ronn/document.rb:459:in `each'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:459:in `html_filter_manual_reference_links'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:312:in `process_html!'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:216:in `html'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:252:in `to_html_fragment'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:228:in `to_roff'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:222:in `send'
        from /home/vagrant/work/ronn/lib/ronn/document.rb:222:in `convert'
        from /home/vagrant/work/ronn/bin/ronn:191
        from /home/vagrant/work/ronn/bin/ronn:181:in `each'
        from /home/vagrant/work/ronn/bin/ronn:181
        from /home/vagrant/work/ronn/bin/ronn:167:in `each'
        from /home/vagrant/work/ronn/bin/ronn:167
```

e3504f2b751e09572535538f6b674b4ee1059c17 is the actual fix for this issue.
