### PR TITLE
Mention Pandoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ronn capabilities:
 
 [1]: http://github.com/rtomayko/ronn/tree/master/man
 
+As an alternative, you might want to check out [pandoc](http://johnmacfarlane.net/pandoc/) which can also convert markdown into roff manual pages.
+
 ## Examples
 
 Build roff and HTML output files for one or more input files:

--- a/man/ronn.1.ronn
+++ b/man/ronn.1.ronn
@@ -302,4 +302,4 @@ Ronn is Copyright (C) 2009 Ryan Tomayko <http://tomayko.com/about>
 
 ## SEE ALSO
 
-ronn-format(7), manpages(5), man(1), roff(7), groff(1), markdown(7)
+groff(1), man(1), manpages(5), markdown(7), roff(7), ronn-format(7)

--- a/man/ronn.1.ronn
+++ b/man/ronn.1.ronn
@@ -302,4 +302,4 @@ Ronn is Copyright (C) 2009 Ryan Tomayko <http://tomayko.com/about>
 
 ## SEE ALSO
 
-ronn-format(7), manpages(5), man(1), roff(7), groff(1), markdown(7)
+ronn-format(7), manpages(5), man(1), roff(7), groff(1), markdown(7), pandoc(1)


### PR DESCRIPTION
`ronn` is not packaged in too many distributions (I know of Arch and Debian Unstable), whereas `pandoc` is packaged more widely (Debian, Ubuntu, Fedora).

People who search for `markdown to man page` find this project, but then might not find a package in their distribution (or Mac OS X or Windows even). It would be nice to tell them that there is a tool for markdown to roff conversion, although it's HTML does not look as slick as ronn's.
