### PR TITLE
meta tags don't have an attribute 'value'

### DIFF
--- a/lib/ronn/template/default.html
+++ b/lib/ronn/template/default.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='{{ generator }}'>
+  <meta charset='utf-8'>
+  <meta name='generator' content='{{ generator }}'>
   <title>{{ title }}</title>
   {{{ stylesheet_tags }}}
 </head>


### PR DESCRIPTION
I think it is nice to have a valid HTML output file…  The validator also want’s to see `utf-8` instead of `utf8`.
