### PR TITLE
Removed unnecessary fields from the gemspec and restricted gem dependencies.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ file 'ronn.gemspec' => FileList['{lib,test,bin}/**','Rakefile'] do |f|
   head.sub!(/\.version = '.*'/, ".version = '#{source_version}'")
   # determine file list from git ls-files
   files = `git ls-files`.
-    split("\n").
+    split($\).
     sort.
     reject{ |file| file =~ /^\./ }.
     reject { |file| file =~ /^doc/ }.

--- a/Rakefile
+++ b/Rakefile
@@ -129,8 +129,8 @@ file 'ronn.gemspec' => FileList['{lib,test,bin}/**','Rakefile'] do |f|
   files = `git ls-files`.
     split($\).
     sort.
-    reject{ |file| file =~ /^\./ }.
-    reject { |file| file =~ /^doc/ }.
+    reject{ |file| file.start_with?('.') }.
+    reject{ |file| file.start_with?('doc') }.
     map{ |file| "    #{file}" }.
     join("\n")
   # piece file back together and write...

--- a/Rakefile
+++ b/Rakefile
@@ -123,9 +123,8 @@ file 'ronn.gemspec' => FileList['{lib,test,bin}/**','Rakefile'] do |f|
   # read spec file and split out manifest section
   spec = File.read(f.name)
   head, manifest, tail = spec.split("  # = MANIFEST =\n")
-  # replace version and date
+  # replace version
   head.sub!(/\.version = '.*'/, ".version = '#{source_version}'")
-  head.sub!(/\.date = '.*'/, ".date = '#{Date.today.to_s}'")
   # determine file list from git ls-files
   files = `git ls-files`.
     split("\n").

--- a/ronn.gemspec
+++ b/ronn.gemspec
@@ -92,5 +92,4 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Ronn"]
   s.require_paths = %w[lib]
-  s.rubygems_version = '1.1.1'
 end

--- a/ronn.gemspec
+++ b/ronn.gemspec
@@ -85,9 +85,9 @@ Gem::Specification.new do |s|
   s.test_files = s.files.select { |path| path =~ /^test\/.*_test.rb/ }
 
   s.extra_rdoc_files = %w[COPYING AUTHORS]
-  s.add_dependency 'hpricot',     '>= 0.8.2'
-  s.add_dependency 'rdiscount',   '>= 1.5.8'
-  s.add_dependency 'mustache',    '>= 0.7.0'
+  s.add_dependency 'hpricot',     '~> 0.8', '>= 0.8.2'
+  s.add_dependency 'rdiscount',   '~> 1.5', '>= 1.5.8'
+  s.add_dependency 'mustache',    '~> 0.7', '>= 0.7.0'
 
   s.has_rdoc = true
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Ronn"]

--- a/ronn.gemspec
+++ b/ronn.gemspec
@@ -2,8 +2,8 @@ Gem::Specification.new do |s|
   s.name = 'ronn'
   s.version = '0.7.3'
 
-  s.description = "Builds manuals"
   s.summary     = "Builds manuals"
+  s.description = "Ronn builds manuals. It converts simple, human readable textfiles to roff for terminal display, and also to HTML for the web."
   s.homepage    = "http://rtomayko.github.com/ronn"
 
   s.authors     = ["Ryan Tomayko"]

--- a/ronn.gemspec
+++ b/ronn.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'ronn'
   s.version = '0.7.3'
-  s.date = '2010-06-24'
 
   s.description = "Builds manuals"
   s.summary     = "Builds manuals"


### PR DESCRIPTION
- Removed unnecessary fields from the gemspec (`date` and `rubygems_version`).
- Restricted the gem dependencies by specifying two version requirements (`'~> 0.8', '>= 0.8.2'`).
