### PR TITLE
Fix treatment of dots at start of line

### DIFF
--- a/lib/ronn/roff.rb
+++ b/lib/ronn/roff.rb
@@ -17,7 +17,10 @@ module Ronn
     end
 
     def to_s
-      @buf.join.gsub(/[ \t]+$/, '')
+      str = @buf.join
+      str.gsub!(/[ \t]+$/, '')                      # trailing whitespace
+      str.gsub!(/^(\s*)\\\./) { "#{$1}\\[char46]" } # special treatment for lines starting with period
+      str
     end
 
   protected
@@ -269,11 +272,6 @@ module Ronn
     # write text to output buffer
     def write(text)
       return if text.nil? || text.empty?
-      # lines cannot start with a '.'. insert zero-width character before.
-      if text[0,2] == '\.' &&
-        (@buf.last && @buf.last[-1] == ?\n)
-        @buf << '\&'
-      end
       @buf << text
     end
 

--- a/test/dots_at_line_start_test.roff
+++ b/test/dots_at_line_start_test.roff
@@ -7,4 +7,19 @@
 There\'s a weird issue where dots at the beginning of a line generate troff warnings due to escaping\.
 .
 .P
-\&\.\. let\'s see what happens\.
+\[char46]\. let\'s see what happens\.
+.
+.P
+This is also an issue with code blocks
+.
+.IP "" 4
+.
+.nf
+
+\[char46]/example_one
+\[char46]/example_two
+.
+.fi
+.
+.IP "" 0
+

--- a/test/dots_at_line_start_test.ronn
+++ b/test/dots_at_line_start_test.ronn
@@ -2,3 +2,8 @@ There's a weird issue where dots at the beginning of a line
 generate troff warnings due to escaping.
 
 .. let's see what happens.
+
+This is also an issue with code blocks
+
+    ./example_one
+    ./example_two

--- a/test/markdown_syntax.roff
+++ b/test/markdown_syntax.roff
@@ -1447,7 +1447,7 @@ _   underscore
 #   hash mark
 +   plus sign
 \-   minus sign (hyphen)
-\.   dot
+\[char46]   dot
 !   exclamation mark
 .
 .fi


### PR DESCRIPTION
Periods at the start of a line cause issues for groff.  The normal escape sequence for periods (`\.`) causes lines to disappear when they are the first non-whitespace characters, even though the escape works elsewhere.

One solution is to write periods at the start of a line as `\[char46]` (see [escaping dots in groff](http://stackoverflow.com/questions/11469341/escaping-dots-in-groff)).  This commit adds this special escape and adds-to or fixes tests as appropriate.
