### PR TITLE
Squeeze blank lines by default for -m output

### DIFF
--- a/bin/ronn
+++ b/bin/ronn
@@ -74,7 +74,7 @@ options = {}
 write_index = false
 styles  = %w[man]
 groff   = "groff -Wall -mtty-char -mandoc -Tascii"
-pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'more'
+pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'more -s'
 
 ##
 # Environment variables


### PR DESCRIPTION
A limited, informal survey of the default pager for man indicates that squeezing blank lines is typical.  The result is a tidier output.

Surveyed:
- [Ubuntu](http://manpages.ubuntu.com/manpages/precise/en/man1/man.1.html)
  pager -s
- [OSX](https://developer.apple.com/library/mac/#documentation/darwin/reference/manpages/man1/man.1.html#//apple_ref/doc/man/1/man)
  less -is
- ["Linux"](http://linux.about.com/od/commands/l/blcmdl1_man.htm)
  /usr/bin/less -isr

This addresses issue #63.
