### PR TITLE
Fix generated manual page date

### DIFF
--- a/lib/ronn/roff.rb
+++ b/lib/ronn/roff.rb
@@ -33,7 +33,7 @@ module Ronn
       comment "generated with Ronn/v#{Ronn.version}"
       comment "http://github.com/rtomayko/ronn/tree/#{Ronn.revision}"
       return if name.nil?
-      macro "TH", %["#{escape(name.upcase)}" "#{section}" "#{date.strftime('%B %Y')}" "#{version}" "#{manual}"]
+      macro "TH", %["#{escape(name.upcase)}" "#{section}" "#{date.strftime('%B %d %Y')}" "#{version}" "#{manual}"]
     end
 
     def remove_extraneous_elements!(doc)

--- a/lib/ronn/template.rb
+++ b/lib/ronn/template.rb
@@ -67,7 +67,7 @@ module Ronn
     end
 
     def date
-      @document.date.strftime('%B %Y')
+      @document.date.strftime('%B %d %Y')
     end
 
     def wrap_class_name


### PR DESCRIPTION
The date must contain the day or else you get warnings like 

./hub.1:4:15: WARNING: cannot parse date, using it verbatim
