### PR TITLE
add charset='utf-8' to default template

### DIFF
--- a/lib/ronn/template/default.html
+++ b/lib/ronn/template/default.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta charset='utf-8'>
   <meta name='generator' value='{{ generator }}'>
   <title>{{ title }}</title>
   {{{ stylesheet_tags }}}


### PR DESCRIPTION
That way it is possible to use unicode characters in text, like m-dash or ellipsis.
