### PR TITLE
Minor change to document.rb to prevent exception if sibling is nil

### DIFF
--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -461,10 +461,12 @@ module Ronn
         next if child_of?(node, 'a')
         next unless node.inner_text =~ /^#{name_pattern}$/
         sibling = node.next
-        next unless sibling.text?
-        next unless sibling.content =~ /^\((\d+\w*)\)/
-        node.swap(html_build_manual_reference_link(node, "(#{$1})"))
-        sibling.content = sibling.content.gsub(/^\(\d+\w*\)/, '')
+        if sibling
+          next unless sibling.text?
+          next unless sibling.content =~ /^\((\d+\w*)\)/
+          node.swap(html_build_manual_reference_link(node, "(#{$1})"))
+          sibling.content = sibling.content.gsub(/^\(\d+\w*\)/, '')
+        end
       end
 
     end


### PR DESCRIPTION
Nothing major, just came across a situation where sibling was nil (with valid ronn/markdown) and an exception was thrown.

Maybe on your next pass you could merge this one too?

Cheers! 
