### PR TITLE
splitting hairs/dashes

### DIFF
--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -400,7 +400,7 @@ module Ronn
         elsif name
           "<h2>NAME</h2>\n" +
           "<p class='man-name'>\n  <code>#{name}</code>" +
-          (tagline ? " - <span class='man-whatis'>#{tagline}</span>\n" : "\n") +
+          (tagline ? " &mdash; <span class='man-whatis'>#{tagline}</span>\n" : "\n") +
           "</p>\n"
         end
       if markup

--- a/lib/ronn/template.rb
+++ b/lib/ronn/template.rb
@@ -38,7 +38,7 @@ module Ronn
       if !name_and_section? && tagline
         tagline
       else
-        [page_name, tagline].compact.join(' - ')
+        [page_name, tagline].compact.join(' &mdash; ')
       end
     end
 

--- a/lib/ronn/template/default.html
+++ b/lib/ronn/template/default.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
   <meta name='generator' value='{{ generator }}'>
-  <title>{{ title }}</title>
+	<title>{{{ title }}}</title>
   {{{ stylesheet_tags }}}
 </head>
 <!--


### PR DESCRIPTION
I was surprised to see that ronn replaces the double-hyphen in the tagline with a single hyphen when technically, a double hyphen would be more correct typographically. An actual dash would have been ideal. This commit makes the double hyphen into an m-dash.

Interestingly, most manpages seem to (incorrectly?) use a single hyphen. The manpage of the dash shell uses a proper m-dash (like this commit).
