### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:alpine
+
+RUN apk add make gcc libc-dev
+RUN gem install ronn
+
+ENTRYPOINT ["/usr/local/bundle/bin/ronn"]


### PR DESCRIPTION
This PR adds a Dockerfile based on Alpine.

A ronn Dockerfile is useful for Continuous Integration tools (such as GitLab CI), to automatically generate a man page during a build process.

This Dockerfile is currently hosted [on Docker hub](https://hub.docker.com/repository/docker/roipoussiere/ronn). If this PR is merged, I can transfer ownship to an other Docker hub user or organization.

## Usage

I recommend to use this container with stdin and stdout, in this way we don't have to deal with Docker volumes.

Saving `./my_program.1.ronn` manpage to `./my_program.1`:

    docker run --rm -i roipoussiere/ronn --roff --pipe < ./my_program.1.ronn > ./my_program.1

Saving `./my_program.1.ronn` html manpage to `./my_program.1.html`:

    docker run --rm -i roipoussiere/ronn --html --pipe < ./my_program.1.ronn > ./my_program.1.html

## Usage in CI

The image entrypoint must be overridden in your CI tool. For instance, if GitLab CI is used, the `.gitlab-ci.yml` could look like this:

```yml
man:
  image:
    name: roipoussiere/ronn
    entrypoint: ["/bin/sh", "-c"]
  script:
    - ronn --roff --pipe ./my_script.1.ronn > ./my_script.1.ronn
    - ronn --html --pipe ./my_script.1.ronn > ./my_script.1.html
```